### PR TITLE
Fix Slack join URL in the metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: true
 contact_links:
   - name: Community forum
-    url: https://join.slack.com/t/wiremock-community/shared_invite/zt-1mkbo0zlx-gxeZdTJ15Kchdt888Fn_1A
+    url: http://slack.wiremock.org/
     about: "You can discuss any ideas on Slack, in #general or another relevant channel"
 


### PR DESCRIPTION
For https://github.com/wiremock/wiremock.org-sources/issues/31