### PR TITLE
Add Maven Central documentation and guide for automating releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
-  - name: Community forum
+  - name: Community Slack
     url: http://slack.wiremock.org/
-    about: "You can discuss any ideas on Slack, in #general or another relevant channel"
+    about: "You can discuss any ideas on Slack, in #general, #help-contributing or another relevant channel"
 

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -13,5 +13,5 @@ body:
   - type: textarea
     attributes:
       label: References
-      label: Reference any relevant documentation, other materials or issues/pull requests that can be used for inspiration.
+      description: Reference any relevant documentation, other materials or issues/pull requests that can be used for inspiration.
  

--- a/.github/ISSUE_TEMPLATE/maven-central.yml
+++ b/.github/ISSUE_TEMPLATE/maven-central.yml
@@ -1,0 +1,34 @@
+name: '🌐 Maven Central Hosting'
+labels: ['community', 'infrastructure']
+description: 'Hosting new Maven projects with release automation to Maven Central'
+
+body:
+  - type: input
+    attributes:
+      label: Repo URL
+      description: |
+        Repository to be hosted. If it is not on the WireMock GitHub org,
+        it will need to be transferred.
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Group ID
+      description: Maven groupID
+
+  - type: input
+    attributes:
+      label: Artifact ID
+      description: Maven artifactID
+
+  - type: input
+    attributes:
+      label: Users with release rights
+      description: List of OSSRH users who should also get permissions
+      value: 'wiremock-release-bot'
+  
+  - type: textarea
+    attributes:
+      label: Details and References
+      description: Any additional context and links

--- a/infra/README.md
+++ b/infra/README.md
@@ -5,6 +5,7 @@ This directory contains notes for different project and community infrastructure
 ## Projects
 
 - [GitHub](./github.md) - `@wiremock` GitHub org
+- [Maven Central](./maven-central.md)
 - [NPM](./npm.md) - we have a `~wiremock` organization there
 - PyPi - a shared [@wiremock](https://pypi.org/user/wiremock/) user that is used for release automation
   and that owns official Python packages.

--- a/infra/maven-central.md
+++ b/infra/maven-central.md
@@ -1,0 +1,104 @@
+# WireMock on Maven Central
+
+WireMock has a lot of Java/JVM components,
+and we do provide some automation for releasing to
+the `org.wiremock` group which is administered by the
+WireMock BDFL and other repository admins.
+
+## Repository structure
+
+- `org.wiremock` as a root. Core components like `wiremock` or `wiremock-standalone` will be under this root
+  - `org.wiremock.extensions` - groupID for extensions
+  - `org.wiremock.tools` - groupID for any associated developer tools (e.g. Maven plugins)
+  - `org.wiremock.integrations.{type}` - groupID for integration libraries
+    - `{type}`- A subgroup defining type of the integration, for example `testcontainers`, `springboot` or `kotlin`
+
+## Setting up the release automation
+
+### Getting access for a project
+
+1. Submit a ticket using the _Maven Central Hosting_ issue template,
+   provide all data there
+2. If the repository is not on the `wiremock` GitHub organization,
+   you will need to transfer it first.
+3. COMING SOON - Sign the Contributor License Agreement.
+   We need it to provide such an advanced permission like releasing with
+   WireMock community signing keys.
+4. Wait till the request is processed.
+   The team will take care of OSSRH requests and provision secret variables
+5. Setup the release automation on GitHub Releases
+
+### Setting up GitHub Actions
+
+The WireMock repository admins will provision 4 secret variables to the repository:
+
+- `OSSRH_USERNAME` - username to be used for upload
+- `OSSRH_TOKEN` - token/password to be used
+- `OSSRH_GPG_SECRET_KEY` - private GPG key, all JARs deployed to Maven Central must be signed with it
+- `OSSRH_GPG_SECRET_KEY_PASSWORD` - Password key for this secret
+
+So, you will need to setup release steps in GitHub Actions to do the deployment.
+We are yet to release custom GitHub Actions,
+so for now you will need to copy&paste the code.
+Normally we recommend releasing to both GitHub Packages and Maven Central,
+hence some magic is needed.
+
+#### For Maven
+
+```yaml
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure Git user
+        run: |
+            git config user.email "actions@github.com"
+            git config user.name "GitHub Actions"
+
+      - id: install-secret-key
+        name: Install gpg secret key
+        run: |
+          # Install gpg secret key
+          cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
+          # Verify gpg secret key
+          gpg --list-secret-keys --keyid-format LONG
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          server-id: github
+          distribution: 'temurin'
+          cache: maven
+ 
+      - name: Set Release Version
+        id: vars
+        shell: bash
+        run: |
+          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          mvn -ntp --batch-mode versions:set -DnewVersion=${{ github.event.inputs.version }}
+          git diff-index --quiet HEAD || git commit -m "Releasing version ${{ github.event.inputs.version }}" pom.xml
+        
+      - name: Publish to GitHub Packages
+        run: mvn -ntp --batch-mode -Dgpg.passphrase="${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}" clean deploy -Prelease
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Set up Java for publishing to Maven Central
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Publish to the Maven Central
+        run: mvn --batch-mode -Dgpg.passphrase="${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}" clean deploy -Prelease,mavencentral-release
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+```
+
+#### For Gradle
+
+A sample is coming soon!


### PR DESCRIPTION


## References

- #44 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
